### PR TITLE
Feature/dev 5641 migrate to es cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.5.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.15.0
 
 RUN bin/elasticsearch-plugin install --batch analysis-icu
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ projectBaseName = "infra-elasticsearch"
 shortLabel = projectBaseName.size() >= 10 ? projectBaseName.substring(0, 10) : projectBaseName
 buildLabel = "${shortLabel}-${UUID.randomUUID().toString()}"
 
-imageVersion = "001"
+imageVersion = "002"
 elasticsearchVersion = "7.15.0"
 imageName = "${projectBaseName}:${elasticsearchVersion}-${imageVersion}"
 imageNameWithPath = "eu.gcr.io/campanda-docker/${imageName}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ shortLabel = projectBaseName.size() >= 10 ? projectBaseName.substring(0, 10) : p
 buildLabel = "${shortLabel}-${UUID.randomUUID().toString()}"
 
 imageVersion = "001"
-elasticsearchVersion = "7.5.1"
+elasticsearchVersion = "7.15.0"
 imageName = "${projectBaseName}:${elasticsearchVersion}-${imageVersion}"
 imageNameWithPath = "eu.gcr.io/campanda-docker/${imageName}"
 maxCommits = 10
@@ -17,16 +17,16 @@ podTemplate(label: "global") {
     podTemplate(
         label: buildLabel,
         containers: [
-                containerTemplate(name: "kaniko", image: "gcr.io/kaniko-project/executor:debug-v1.3.0", ttyEnabled: true, command: "/busybox/cat",
-                        envVars: [
-                                containerEnvVar(key: "GOOGLE_APPLICATION_CREDENTIALS", value: "/secret/campanda-docker-account.json")
-                        ]
-                ),
+            containerTemplate(name: "kaniko", image: "gcr.io/kaniko-project/executor:debug-v1.3.0", ttyEnabled: true, command: "/busybox/cat",
+                envVars: [
+                    containerEnvVar(key: "GOOGLE_APPLICATION_CREDENTIALS", value: "/secret/campanda-docker-account.json")
+                ]
+            ),
         ],
         envVars: defaultEnvList,
         nodeSelector: "type=worker",
         volumes: [
-                secretVolume(secretName: "campanda-docker-account", mountPath: "/secret"),
+            secretVolume(secretName: "campanda-docker-account", mountPath: "/secret"),
         ]
     ) {
         node(buildLabel) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 projectBaseName = "infra-elasticsearch"
-elasticsearch_version = "7.5.1-erento-002"
+elasticsearch_version = "7.5.1-001"
 
 imageName = "${projectBaseName}:${elasticsearch_version}"
 
@@ -9,7 +9,7 @@ node {
     }
 
     stage("bake and push service image") {
-        def myImage = docker.build("eu.gcr.io/erento-docker/${imageName}", ".")
+        def myImage = docker.build("eu.gcr.io/campanda-docker/${imageName}", ".")
         myImage.push()
         myImage.push('latest')
         milestone(label: "image baked and pushed")

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The elasticsearch infrastructure is based on the official [HELM chart](https://github.com/elastic/helm-charts) from 3. January 2020 and elasticsearch version `7.5.1`.
 
-HELM is required in the version 2.
+HELM is required in the version > 2.
 
 ## How to proceed to install elastic from scratch
 
@@ -30,15 +30,21 @@ helm install --name elasticsearch-client --values deploy/client.yml elastic/elas
 
 ## Create new docker image with elasticsearch
 
-The docker image is built in the CI and pushed to `erento-docker` container registry. The docker image version is specified in the Dockerfile & Jenkinsfile (both have to be updated after upgrade).
+The docker image is built in the CI and pushed to `campanda-docker` container registry. The docker image version is specified in the Dockerfile & Jenkinsfile (both have to be updated after upgrade).
 _Please remember that creating the docker image with the same image name and tag will most likely not install correct image because the downloaded images are cached and therefore the old image will be used._
 
 If you create a new docker image you have to modify the image tag in `/deploy/*.yml` files.
 
 To build the image manually (e.g.: for testing locally) run:
 ```bash
-docker build -t erento_elastic_search .
+docker build -t campanda_elastic_search .
 ```
+To push to the registry manually run:
+```bash
+docker build . -t eu.gcr.io/campanda-docker/infra-elasticsearch:7.5.1-campanda-XXX
+docker push eu.gcr.io/campanda-docker/infra-elasticsearch:7.5.1-campanda-XXX
+```
+**Note:** replace `XXX` with a sequential number (first tag is `7.5.1-001`).
 
 ## Test
 Create a new cluster:
@@ -85,7 +91,7 @@ Afterwards replace or add `xx_XX.dic` and `xx_XX.aff` in `/hunspell/xx_XX/` and 
 
 - When the elasticsearch pods are down, look at the following [post mortem report](https://erento.atlassian.net/wiki/spaces/dev/pages/963674119/2020-03-03+-+frontend+not+serving+any+content+due+to+elasticsearch+issue).
 
-## How to use our elastic outside of erento
+## How to use our elastic outside campanda
 
 - Please, fork our repository. It will help us to follow your changes and give you a possibility to pull any future upgrades we will provide over time.
 - Change `dictionaries/synonyms.txt` to be aligned with your business.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elasticsearch infrastructure
 
-The elasticsearch infrastructure is based on the official [HELM chart](https://github.com/elastic/helm-charts) from 3. January 2020 and elasticsearch version `7.5.1`.
+The elasticsearch infrastructure is based on the official [HELM chart](https://github.com/elastic/helm-charts) from 7. October 2021 and elasticsearch version `7.15.0`.
 
 HELM is required in the version 3.
 
@@ -23,9 +23,9 @@ helm repo add elastic https://helm.elastic.co
 
 To install elasticsearch using helm follow these steps (can be applied at the same time, the order is not important):
 ```bash
-helm install elasticsearch-master -f deploy/master.yml elastic/elasticsearch
-helm install elasticsearch-data -f deploy/data.yml elastic/elasticsearch
-helm install elasticsearch-client -f deploy/client.yml elastic/elasticsearch
+helm install elasticsearch-master -f deploy/master.yml elastic/elasticsearch --version 7.15.0
+helm install elasticsearch-data -f deploy/data.yml elastic/elasticsearch --version 7.15.0
+helm install elasticsearch-client -f deploy/client.yml elastic/elasticsearch --version 7.15.0
 ```
 
 ## Create new docker image with elasticsearch
@@ -41,10 +41,10 @@ docker build -t campanda_elastic_search .
 ```
 To push to the registry manually run:
 ```bash
-docker build . -t eu.gcr.io/campanda-docker/infra-elasticsearch:7.5.1-campanda-XXX
-docker push eu.gcr.io/campanda-docker/infra-elasticsearch:7.5.1-campanda-XXX
+docker build . -t eu.gcr.io/campanda-docker/infra-elasticsearch:7.15.0-campanda-XXX
+docker push eu.gcr.io/campanda-docker/infra-elasticsearch:7.15.0-campanda-XXX
 ```
-**Note:** replace `XXX` with a sequential number (first tag is `7.5.1-001`). 
+**Note:** replace `XXX` with a sequential number (first tag is `7.15.0-001`). 
 Check the [container registry](https://console.cloud.google.com/gcr/images/campanda-docker/eu/infra-elasticsearch?project=campanda-docker) for latest number.
 
 ## Test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The elasticsearch infrastructure is based on the official [HELM chart](https://github.com/elastic/helm-charts) from 3. January 2020 and elasticsearch version `7.5.1`.
 
-HELM is required in the version > 2.
+HELM is required in the version 3.
 
 ## How to proceed to install elastic from scratch
 
@@ -23,9 +23,9 @@ helm repo add elastic https://helm.elastic.co
 
 To install elasticsearch using helm follow these steps (can be applied at the same time, the order is not important):
 ```bash
-helm install --name elasticsearch-master --values deploy/master.yml elastic/elasticsearch
-helm install --name elasticsearch-data --values deploy/data.yml elastic/elasticsearch
-helm install --name elasticsearch-client --values deploy/client.yml elastic/elasticsearch
+helm install elasticsearch-master -f deploy/master.yml elastic/elasticsearch
+helm install elasticsearch-data -f deploy/data.yml elastic/elasticsearch
+helm install elasticsearch-client -f deploy/client.yml elastic/elasticsearch
 ```
 
 ## Create new docker image with elasticsearch
@@ -44,7 +44,8 @@ To push to the registry manually run:
 docker build . -t eu.gcr.io/campanda-docker/infra-elasticsearch:7.5.1-campanda-XXX
 docker push eu.gcr.io/campanda-docker/infra-elasticsearch:7.5.1-campanda-XXX
 ```
-**Note:** replace `XXX` with a sequential number (first tag is `7.5.1-001`).
+**Note:** replace `XXX` with a sequential number (first tag is `7.5.1-001`). 
+Check the [container registry](https://console.cloud.google.com/gcr/images/campanda-docker/eu/infra-elasticsearch?project=campanda-docker) for latest number.
 
 ## Test
 Create a new cluster:

--- a/deploy/_2021.10.07_values.yml
+++ b/deploy/_2021.10.07_values.yml
@@ -7,11 +7,19 @@ nodeGroup: "master"
 masterService: ""
 
 # Elasticsearch roles that will be applied to this nodeGroup
-# These will be set as environment variables. E.g. node.master=true
+# These will be set as environment variables. E.g. node.roles=master
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html#node-roles
 roles:
-  master: "true"
-  ingest: "true"
-  data: "true"
+  - master
+  - data
+  - data_content
+  - data_hot
+  - data_warm
+  - data_cold
+  - ingest
+  - ml
+  - remote_cluster_client
+  - transform
 
 replicas: 3
 minimumMasterNodes: 2
@@ -34,6 +42,13 @@ extraEnvs: []
 #  - name: MY_ENVIRONMENT_VAR
 #    value: the_value_goes_here
 
+# Allows you to load environment variables from kubernetes secret or config map
+envFrom: []
+# - secretRef:
+#     name: env-secret
+# - configMapRef:
+#     name: config-map
+
 # A list of secrets and their paths to mount inside the pod
 # This is useful for mounting certificates for security and for mounting
 # the X-Pack license
@@ -41,9 +56,16 @@ secretMounts: []
 #  - name: elastic-certificates
 #    secretName: elastic-certificates
 #    path: /usr/share/elasticsearch/config/certs
+#    defaultMode: 0755
+
+hostAliases: []
+#- ip: "127.0.0.1"
+#  hostnames:
+#  - "foo.local"
+#  - "bar.local"
 
 image: "docker.elastic.co/elasticsearch/elasticsearch"
-imageTag: "7.5.1"
+imageTag: "8.0.0-SNAPSHOT"
 imagePullPolicy: "IfNotPresent"
 
 podAnnotations: {}
@@ -52,25 +74,17 @@ podAnnotations: {}
 # additionals labels
 labels: {}
 
-esJavaOpts: "-Xmx1g -Xms1g"
+esJavaOpts: "" # example: "-Xmx1g -Xms1g"
 
 resources:
   requests:
-    cpu: "100m"
+    cpu: "1000m"
     memory: "2Gi"
   limits:
     cpu: "1000m"
     memory: "2Gi"
 
 initResources: {}
-  # limits:
-  #   cpu: "25m"
-  #   # memory: "128Mi"
-  # requests:
-  #   cpu: "25m"
-#   memory: "128Mi"
-
-sidecarResources: {}
   # limits:
   #   cpu: "25m"
   #   # memory: "128Mi"
@@ -88,7 +102,9 @@ volumeClaimTemplate:
 
 rbac:
   create: false
+  serviceAccountAnnotations: {}
   serviceAccountName: ""
+  automountToken: true
 
 podSecurityPolicy:
   create: false
@@ -107,21 +123,30 @@ podSecurityPolicy:
       - secret
       - configMap
       - persistentVolumeClaim
+      - emptyDir
 
 persistence:
   enabled: true
+  labels:
+    # Add default labels for the volumeClaimTemplate of the StatefulSet
+    enabled: false
   annotations: {}
 
-extraVolumes: ""
+extraVolumes: []
   # - name: extras
 #   emptyDir: {}
 
-extraVolumeMounts: ""
+extraVolumeMounts: []
   # - name: extras
   #   mountPath: /usr/share/extras
 #   readOnly: true
 
-extraInitContainers: ""
+extraContainers: []
+  # - name: do-something
+  #   image: busybox
+#   command: ['do', 'something']
+
+extraInitContainers: []
   # - name: do-something
   #   image: busybox
 #   command: ['do', 'something']
@@ -146,11 +171,17 @@ nodeAffinity: {}
 # the same time when bootstrapping the cluster
 podManagementPolicy: "Parallel"
 
+# The environment variables injected by service links are not used, but can lead to slow Elasticsearch boot times when
+# there are many services in the current namespace.
+# If you experience slow pod startups you probably want to set this to `false`.
+enableServiceLinks: true
+
 protocol: http
 httpPort: 9200
 transportPort: 9300
 
 service:
+  enabled: true
   labels: {}
   labelsHeadless: {}
   type: ClusterIP
@@ -158,6 +189,9 @@ service:
   annotations: {}
   httpPortName: http
   transportPortName: transport
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+  externalTrafficPolicy: ""
 
 updateStrategy: RollingUpdate
 
@@ -169,10 +203,6 @@ maxUnavailable: 1
 podSecurityContext:
   fsGroup: 1000
   runAsUser: 1000
-
-# The following value is deprecated,
-# please use the above podSecurityContext.fsGroup instead
-fsGroup: ""
 
 securityContext:
   capabilities:
@@ -206,16 +236,17 @@ imagePullSecrets: []
 nodeSelector: {}
 tolerations: []
 
-# Enabling this will publically expose your Elasticsearch instance.
+# Enabling this will publicly expose your Elasticsearch instance.
 # Only enable this if you have security enabled on your cluster
 ingress:
   enabled: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
-  path: /
   hosts:
-    - chart-example.local
+    - host: chart-example.local
+      paths:
+        - path: /
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
@@ -223,9 +254,7 @@ ingress:
 
 nameOverride: ""
 fullnameOverride: ""
-
-# https://github.com/elastic/helm-charts/issues/63
-masterTerminationFix: false
+healthNameOverride: ""
 
 lifecycle: {}
   # preStop:
@@ -233,9 +262,83 @@ lifecycle: {}
   #     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
   # postStart:
   #   exec:
-#     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
+  #     command:
+  #       - bash
+  #       - -c
+  #       - |
+  #         #!/bin/bash
+  #         # Add a template to adjust number of shards/replicas
+  #         TEMPLATE_NAME=my_template
+  #         INDEX_PATTERN="logstash-*"
+  #         SHARD_COUNT=8
+  #         REPLICA_COUNT=1
+  #         ES_URL=http://localhost:9200
+  #         while [[ "$(curl -s -o /dev/null -w '%{http_code}\n' $ES_URL)" != "200" ]]; do sleep 1; done
+#         curl -XPUT "$ES_URL/_template/$TEMPLATE_NAME" -H 'Content-Type: application/json' -d'{"index_patterns":['\""$INDEX_PATTERN"\"'],"settings":{"number_of_shards":'$SHARD_COUNT',"number_of_replicas":'$REPLICA_COUNT'}}'
 
 sysctlInitContainer:
   enabled: true
 
 keystore: []
+
+networkPolicy:
+  ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+  ## In order for a Pod to access Elasticsearch, it needs to have the following label:
+  ## {{ template "uname" . }}-client: "true"
+  ## Example for default configuration to access HTTP port:
+  ## elasticsearch-master-http-client: "true"
+  ## Example for default configuration to access transport port:
+  ## elasticsearch-master-transport-client: "true"
+
+  http:
+    enabled: false
+    ## if explicitNamespacesSelector is not set or set to {}, only client Pods being in the networkPolicy's namespace
+    ## and matching all criteria can reach the DB.
+    ## But sometimes, we want the Pods to be accessible to clients from other namespaces, in this case, we can use this
+    ## parameter to select these namespaces
+    ##
+    # explicitNamespacesSelector:
+    #   # Accept from namespaces with all those different rules (only from whitelisted Pods)
+    #   matchLabels:
+    #     role: frontend
+    #   matchExpressions:
+    #     - {key: role, operator: In, values: [frontend]}
+
+    ## Additional NetworkPolicy Ingress "from" rules to set. Note that all rules are OR-ed.
+    ##
+    # additionalRules:
+    #   - podSelector:
+    #       matchLabels:
+    #         role: frontend
+    #   - podSelector:
+    #       matchExpressions:
+    #         - key: role
+    #           operator: In
+    #           values:
+    #             - frontend
+
+  transport:
+    ## Note that all Elasticsearch Pods can talks to themselves using transport port even if enabled.
+    enabled: false
+    # explicitNamespacesSelector:
+    #   matchLabels:
+    #     role: frontend
+    #   matchExpressions:
+    #     - {key: role, operator: In, values: [frontend]}
+    # additionalRules:
+    #   - podSelector:
+    #       matchLabels:
+    #         role: frontend
+    #   - podSelector:
+    #       matchExpressions:
+    #         - key: role
+    #           operator: In
+    #           values:
+    #             - frontend
+
+tests:
+  enabled: true
+
+# Deprecated
+# please use the above podSecurityContext.fsGroup instead
+fsGroup: ""

--- a/deploy/_2021.10.07_values.yml
+++ b/deploy/_2021.10.07_values.yml
@@ -1,3 +1,4 @@
+# default values for helm chart taken from: https://github.com/elastic/helm-charts/blob/master/elasticsearch/values.yaml
 ---
 clusterName: "elasticsearch"
 nodeGroup: "master"

--- a/deploy/client.yml
+++ b/deploy/client.yml
@@ -1,6 +1,6 @@
 ---
 image: "eu.gcr.io/campanda-docker/infra-elasticsearch"
-imageTag: "7.15.0-001"
+imageTag: "7.15.0-002"
 replicas: 2
 esMajorVersion: 7
 updateStrategy: OnDelete
@@ -25,89 +25,6 @@ resources:
 
 podAnnotations:
   app.kubernetes.io/name: es-cluster
-
-esConfig:
-  jvm.options: |
-    ## JVM configuration
-
-    ## You should always set the min and max JVM heap size to the same value. For example, to set the heap to 4 GB, set:
-    ## -Xms4g
-    ## -Xmx4g
-    ## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html for more information
-    # Xms represents the initial size of total heap space
-    # Xmx represents the maximum size of total heap space
-
-    -Xms1024m
-    -Xmx1024m
-
-    ## Expert settings
-
-    ## GC configuration
-    -XX:CMSInitiatingOccupancyFraction=75
-    -XX:+UseCMSInitiatingOccupancyOnly
-
-    ## heap dumps
-
-    # generate a heap dump when an allocation from the Java heap fails heap dumps are created in the working directory of the JVM
-    -XX:+HeapDumpOnOutOfMemoryError
-
-    # specify an alternative path for heap dumps; ensure the directory exists and has sufficient space
-    -XX:HeapDumpPath=data
-
-    # specify an alternative path for JVM fatal error logs
-    -XX:ErrorFile=logs/hs_err_pid%p.log
-
-    # JDK 9+ GC logging
-    9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
-
-    ## Company specific
-
-    -XX:+AlwaysPreTouch
-
-    -Xss1m
-
-    -Djava.awt.headless=true
-
-    -Dfile.encoding=UTF-8
-
-    -Djna.nosys=true
-
-    -Djdk.io.permissionsUseCanonicalPath=true
-
-    -Dio.netty.noUnsafe=true
-    -Dio.netty.noKeySetOptimization=true
-    -Dio.netty.recycler.maxCapacityPerThread=0
-
-    -Dlog4j.shutdownHookEnabled=false
-    -Dlog4j2.disable.jmx=true
-    -Dlog4j.skipJansi=true
-  elasticsearch.yml: |
-    path.logs: /usr/share/elasticsearch/logs
-    network.host: 0.0.0.0
-    node:
-      master: false
-      data: false
-      ingest: true
-  log4j2.properties: |
-    status: error
-    logger:
-      action:
-        level: info
-        name: org.elasticsearch.action
-      deprecation:
-        level: warn
-    appender:
-      console:
-        type = Console
-        name = console
-        layout:
-          type = PatternLayout
-          pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
-    rootLogger:
-      level = info,console
-      appenderRef:
-        console:
-          ref: console
 
 # Enable this option when it is not part of your environment (e.g. different namespace or cluster)
 #service:

--- a/deploy/client.yml
+++ b/deploy/client.yml
@@ -1,6 +1,6 @@
 ---
-image: "eu.gcr.io/erento-docker/infra-elasticsearch"
-imageTag: "7.5.1-erento-002"
+image: "eu.gcr.io/campanda-docker/infra-elasticsearch"
+imageTag: "7.5.1-001"
 replicas: 2
 esMajorVersion: 7
 updateStrategy: OnDelete
@@ -61,7 +61,7 @@ esConfig:
     # JDK 9+ GC logging
     9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
 
-    ## Erento specific
+    ## Company specific
 
     -XX:+AlwaysPreTouch
 

--- a/deploy/client.yml
+++ b/deploy/client.yml
@@ -43,7 +43,6 @@ esConfig:
     ## Expert settings
 
     ## GC configuration
-    -XX:+UseConcMarkSweepGC
     -XX:CMSInitiatingOccupancyFraction=75
     -XX:+UseCMSInitiatingOccupancyOnly
 

--- a/deploy/client.yml
+++ b/deploy/client.yml
@@ -1,6 +1,6 @@
 ---
 image: "eu.gcr.io/campanda-docker/infra-elasticsearch"
-imageTag: "7.5.1-001"
+imageTag: "7.15.0-001"
 replicas: 2
 esMajorVersion: 7
 updateStrategy: OnDelete

--- a/deploy/client.yml
+++ b/deploy/client.yml
@@ -5,7 +5,7 @@ replicas: 2
 esMajorVersion: 7
 updateStrategy: OnDelete
 imagePullSecrets:
-  - name: docker-registry-google
+  - name: docker-registry-google-eu
 
 clusterName: "elasticsearch"
 nodeGroup: "client"

--- a/deploy/data.yml
+++ b/deploy/data.yml
@@ -1,6 +1,6 @@
 ---
 image: "eu.gcr.io/campanda-docker/infra-elasticsearch"
-imageTag: "7.15.0-001"
+imageTag: "7.15.0-002"
 replicas: 3
 esMajorVersion: 7
 updateStrategy: OnDelete
@@ -25,89 +25,6 @@ resources:
 
 podAnnotations:
   app.kubernetes.io/name: es-cluster
-
-esConfig:
-  jvm.options: |
-    ## JVM configuration
-
-    ## You should always set the min and max JVM heap size to the same value. For example, to set the heap to 4 GB, set:
-    ## -Xms4g
-    ## -Xmx4g
-    ## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html for more information
-    # Xms represents the initial size of total heap space
-    # Xmx represents the maximum size of total heap space
-
-    -Xms1024m
-    -Xmx1024m
-
-    ## Expert settings
-
-    ## GC configuration
-    -XX:CMSInitiatingOccupancyFraction=75
-    -XX:+UseCMSInitiatingOccupancyOnly
-
-    ## heap dumps
-
-    # generate a heap dump when an allocation from the Java heap fails heap dumps are created in the working directory of the JVM
-    -XX:+HeapDumpOnOutOfMemoryError
-
-    # specify an alternative path for heap dumps; ensure the directory exists and has sufficient space
-    -XX:HeapDumpPath=data
-
-    # specify an alternative path for JVM fatal error logs
-    -XX:ErrorFile=logs/hs_err_pid%p.log
-
-    # JDK 9+ GC logging
-    9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
-
-    ## Company specific
-
-    -XX:+AlwaysPreTouch
-
-    -Xss1m
-
-    -Djava.awt.headless=true
-
-    -Dfile.encoding=UTF-8
-
-    -Djna.nosys=true
-
-    -Djdk.io.permissionsUseCanonicalPath=true
-
-    -Dio.netty.noUnsafe=true
-    -Dio.netty.noKeySetOptimization=true
-    -Dio.netty.recycler.maxCapacityPerThread=0
-
-    -Dlog4j.shutdownHookEnabled=false
-    -Dlog4j2.disable.jmx=true
-    -Dlog4j.skipJansi=true
-  elasticsearch.yml: |
-    path.logs: /usr/share/elasticsearch/logs
-    network.host: 0.0.0.0
-    node:
-      master: false
-      data: true
-      ingest: false
-  log4j2.properties: |
-    status: error
-    logger:
-      action:
-        level: info
-        name: org.elasticsearch.action
-      deprecation:
-        level: warn
-    appender:
-      console:
-        type = Console
-        name = console
-        layout:
-          type = PatternLayout
-          pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
-    rootLogger:
-      level = info,console
-      appenderRef:
-        console:
-          ref: console
 
 volumeClaimTemplate:
   accessModes: [ "ReadWriteOnce" ]

--- a/deploy/data.yml
+++ b/deploy/data.yml
@@ -1,6 +1,6 @@
 ---
 image: "eu.gcr.io/campanda-docker/infra-elasticsearch"
-imageTag: "7.5.1-001"
+imageTag: "7.15.0-001"
 replicas: 3
 esMajorVersion: 7
 updateStrategy: OnDelete

--- a/deploy/data.yml
+++ b/deploy/data.yml
@@ -43,7 +43,6 @@ esConfig:
     ## Expert settings
 
     ## GC configuration
-    -XX:+UseConcMarkSweepGC
     -XX:CMSInitiatingOccupancyFraction=75
     -XX:+UseCMSInitiatingOccupancyOnly
 

--- a/deploy/data.yml
+++ b/deploy/data.yml
@@ -5,7 +5,7 @@ replicas: 3
 esMajorVersion: 7
 updateStrategy: OnDelete
 imagePullSecrets:
-  - name: docker-registry-google
+  - name: docker-registry-google-eu
 
 clusterName: "elasticsearch"
 nodeGroup: "data"

--- a/deploy/data.yml
+++ b/deploy/data.yml
@@ -1,6 +1,6 @@
 ---
-image: "eu.gcr.io/erento-docker/infra-elasticsearch"
-imageTag: "7.5.1-erento-002"
+image: "eu.gcr.io/campanda-docker/infra-elasticsearch"
+imageTag: "7.5.1-001"
 replicas: 3
 esMajorVersion: 7
 updateStrategy: OnDelete
@@ -61,7 +61,7 @@ esConfig:
     # JDK 9+ GC logging
     9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
 
-    ## Erento specific
+    ## Company specific
 
     -XX:+AlwaysPreTouch
 

--- a/deploy/master.yml
+++ b/deploy/master.yml
@@ -1,6 +1,6 @@
 ---
 image: "eu.gcr.io/campanda-docker/infra-elasticsearch"
-imageTag: "7.15.0-001"
+imageTag: "7.15.0-002"
 replicas: 5 # minimal recommended value is 3, but with preemptible instances we recommend 5
 esMajorVersion: 7
 updateStrategy: OnDelete
@@ -25,96 +25,6 @@ resources:
 
 podAnnotations:
   app.kubernetes.io/name: es-cluster
-
-esConfig:
-  jvm.options: |
-    ## JVM configuration
-
-    ## You should always set the min and max JVM heap size to the same value. For example, to set the heap to 4 GB, set:
-    ## -Xms4g
-    ## -Xmx4g
-    ## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html for more information
-    # Xms represents the initial size of total heap space
-    # Xmx represents the maximum size of total heap space
-
-    -Xms1024m
-    -Xmx1024m
-
-    ## Expert settings
-
-    ## GC configuration
-    -XX:CMSInitiatingOccupancyFraction=75
-    -XX:+UseCMSInitiatingOccupancyOnly
-
-    ## heap dumps
-
-    # generate a heap dump when an allocation from the Java heap fails heap dumps are created in the working directory of the JVM
-    -XX:+HeapDumpOnOutOfMemoryError
-
-    # specify an alternative path for heap dumps; ensure the directory exists and has sufficient space
-    -XX:HeapDumpPath=data
-
-    # specify an alternative path for JVM fatal error logs
-    -XX:ErrorFile=logs/hs_err_pid%p.log
-
-    # JDK 9+ GC logging
-    9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
-
-    ## Company specific
-
-    -XX:+AlwaysPreTouch
-
-    -Xss1m
-
-    -Djava.awt.headless=true
-
-    -Dfile.encoding=UTF-8
-
-    -Djna.nosys=true
-
-    -Djdk.io.permissionsUseCanonicalPath=true
-
-    -Dio.netty.noUnsafe=true
-    -Dio.netty.noKeySetOptimization=true
-    -Dio.netty.recycler.maxCapacityPerThread=0
-
-    -Dlog4j.shutdownHookEnabled=false
-    -Dlog4j2.disable.jmx=true
-    -Dlog4j.skipJansi=true
-  elasticsearch.yml: |
-    path.logs: /usr/share/elasticsearch/logs
-    network.host: 0.0.0.0
-    node:
-      master: true
-      data: false
-      ingest: false
-    discovery.seed_hosts: elasticsearch-master-headless
-    cluster.initial_master_nodes:
-      - elasticsearch-master-0
-      - elasticsearch-master-1
-      - elasticsearch-master-2
-      - elasticsearch-master-3
-      - elasticsearch-master-4
-  log4j2.properties: |
-    status: error
-    logger:
-      action:
-        level: info
-        name: org.elasticsearch.action
-      deprecation:
-        level: warn
-    appender:
-      console:
-        type = Console
-        name = console
-        layout:
-          type = PatternLayout
-          pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
-    rootLogger:
-      level = info,console
-      appenderRef:
-        console:
-          ref: console
 
 volumeClaimTemplate:
   accessModes: ["ReadWriteOnce"]

--- a/deploy/master.yml
+++ b/deploy/master.yml
@@ -5,7 +5,7 @@ replicas: 5 # minimal recommended value is 3, but with preemptible instances we 
 esMajorVersion: 7
 updateStrategy: OnDelete
 imagePullSecrets:
-  - name: docker-registry-google
+  - name: docker-registry-google-eu
 
 clusterName: "elasticsearch"
 nodeGroup: "master"

--- a/deploy/master.yml
+++ b/deploy/master.yml
@@ -43,7 +43,6 @@ esConfig:
     ## Expert settings
 
     ## GC configuration
-    -XX:+UseConcMarkSweepGC
     -XX:CMSInitiatingOccupancyFraction=75
     -XX:+UseCMSInitiatingOccupancyOnly
 

--- a/deploy/master.yml
+++ b/deploy/master.yml
@@ -1,6 +1,6 @@
 ---
 image: "eu.gcr.io/campanda-docker/infra-elasticsearch"
-imageTag: "7.5.1-001"
+imageTag: "7.15.0-001"
 replicas: 5 # minimal recommended value is 3, but with preemptible instances we recommend 5
 esMajorVersion: 7
 updateStrategy: OnDelete

--- a/deploy/master.yml
+++ b/deploy/master.yml
@@ -1,6 +1,6 @@
 ---
-image: "eu.gcr.io/erento-docker/infra-elasticsearch"
-imageTag: "7.5.1-erento-002"
+image: "eu.gcr.io/campanda-docker/infra-elasticsearch"
+imageTag: "7.5.1-001"
 replicas: 5 # minimal recommended value is 3, but with preemptible instances we recommend 5
 esMajorVersion: 7
 updateStrategy: OnDelete
@@ -61,7 +61,7 @@ esConfig:
     # JDK 9+ GC logging
     9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
 
-    ## Erento specific
+    ## Company specific
 
     -XX:+AlwaysPreTouch
 


### PR DESCRIPTION
These are the changes which were required after forking and upgrading to the newest chart version (to be able to use helm 3).

Cluster health can be checked over the client: `http://elasticsearch-client:9200/_cluster/health`